### PR TITLE
ca init container refactor

### DIFF
--- a/openshift/consumer.yaml
+++ b/openshift/consumer.yaml
@@ -33,12 +33,12 @@ objects:
           image: ${INTERNAL_CERT_INIT_IMAGE}:${INTERNAL_CERT_INIT_IMAGE_TAG}
           imagePullPolicy: ${INTERNAL_CERT_INIT_IMAGE_PULL_POLICY}
           command: ["/bin/sh", "-c"]
-          args: ["cp /tmp/etc-pki/ca.crt /etc/pki/ca-trust/source/anchors/ca.crt && update-ca-trust"]
+          args: ["update-ca-trust"]
           volumeMounts:
           - name: ca-extracted
             mountPath: /etc/pki/ca-trust/extracted
           - name: ca-certs
-            mountPath: /tmp/etc-pki/ca.crt
+            mountPath: /etc/pki/ca-trust/source/anchors/ca.crt
             subPath: ca.crt
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}

--- a/openshift/consumer.yaml
+++ b/openshift/consumer.yaml
@@ -29,16 +29,16 @@ objects:
       spec:
         serviceAccountName: git-partition-sync-consumer
         initContainers:
-        - name: internal-certificates
+        - name: init-internal-certs
           image: ${INTERNAL_CERT_INIT_IMAGE}:${INTERNAL_CERT_INIT_IMAGE_TAG}
           imagePullPolicy: ${INTERNAL_CERT_INIT_IMAGE_PULL_POLICY}
           command: ["/bin/sh", "-c"]
-          args: ["update-ca-trust && cp -r /etc/pki/. tmp/etc-pki/"]
+          args: ["cp /tmp/etc-pki/ca.crt /etc/pki/ca-trust/source/anchors/ca.crt && update-ca-trust"]
           volumeMounts:
-          - name: internal-certificates
-            mountPath: /tmp/etc-pki/
+          - name: ca-extracted
+            mountPath: /etc/pki/ca-trust/extracted
           - name: ca-certs
-            mountPath: /etc/pki/ca-trust/source/anchors/ca.crt
+            mountPath: /tmp/etc-pki/ca.crt
             subPath: ca.crt
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
@@ -100,12 +100,12 @@ objects:
           volumeMounts:
           - name: sync-ops
             mountPath: ${VOLUME_PATH}
-          - name: internal-certificates
-            mountPath: /etc/pki/
+          - name: ca-extracted
+            mountPath: /etc/pki/ca-trust/extracted
         volumes:
         - name: sync-ops
           emptyDir: {}
-        - name: internal-certificates
+        - name: ca-extracted
           emptyDir: {}
         - name: ca-certs
           secret:


### PR DESCRIPTION
another attempt to circumvent permission issue when executing `update-ca-trust`