### PR TITLE
Refactor approach for importing internal git server cert

### DIFF
--- a/openshift/consumer.yaml
+++ b/openshift/consumer.yaml
@@ -91,19 +91,17 @@ objects:
           - name: sync-ops
             mountPath: ${VOLUME_PATH}
           - name: ca-certs
-            mountPath: /etc/pki/ca-trust/source/anchors/${INTERNAL_GIT_CA_PATH}
-            subPath: ${INTERNAL_GIT_CA_PATH}
+            mountPath: ${INTERNAL_GIT_CA_PATH}
+            subPath: ca.crt
         volumes:
         - name: sync-ops
-          emptyDir: {}
-        - name: ca-extracted
           emptyDir: {}
         - name: ca-certs
           secret:
             secretName: ca-certs
             items:
             - key: ca.crt
-              path: ${INTERNAL_GIT_CA_PATH}
+              path: ca.crt
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/git-partition-sync-consumer
@@ -139,4 +137,4 @@ parameters:
   value: git-partition-sync-consumer
 - name: INTERNAL_GIT_CA_PATH
   description: 'path to certificate file to add in git config trust'
-  value: 'ca.crt'
+  value: '/etc/pki/ca-trust/source/anchors/ca.crt'

--- a/openshift/consumer.yaml
+++ b/openshift/consumer.yaml
@@ -28,18 +28,6 @@ objects:
           app: git-partition-sync-consumer
       spec:
         serviceAccountName: git-partition-sync-consumer
-        initContainers:
-        - name: init-internal-certs
-          image: ${INTERNAL_CERT_INIT_IMAGE}:${INTERNAL_CERT_INIT_IMAGE_TAG}
-          imagePullPolicy: ${INTERNAL_CERT_INIT_IMAGE_PULL_POLICY}
-          command: ["/bin/sh", "-c"]
-          args: ["update-ca-trust"]
-          volumeMounts:
-          - name: ca-extracted
-            mountPath: /etc/pki/ca-trust/extracted
-          - name: ca-certs
-            mountPath: /etc/pki/ca-trust/source/anchors/ca.crt
-            subPath: ca.crt
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
@@ -50,6 +38,8 @@ objects:
             value: ${RECONCILE_SLEEP_TIME}
           - name: WORKDIR
             value: ${VOLUME_PATH}/${WORKDIR}
+          - name: INTERNAL_GIT_CA_PATH
+            value: ${INTERNAL_GIT_CA_PATH}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -100,8 +90,9 @@ objects:
           volumeMounts:
           - name: sync-ops
             mountPath: ${VOLUME_PATH}
-          - name: ca-extracted
-            mountPath: /etc/pki/ca-trust/extracted
+          - name: ca-certs
+            mountPath: /etc/pki/ca-trust/source/anchors/${INTERNAL_GIT_CA_PATH}
+            subPath: ${INTERNAL_GIT_CA_PATH}
         volumes:
         - name: sync-ops
           emptyDir: {}
@@ -112,7 +103,7 @@ objects:
             secretName: ca-certs
             items:
             - key: ca.crt
-              path: ca.crt
+              path: ${INTERNAL_GIT_CA_PATH}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/git-partition-sync-consumer
@@ -122,12 +113,6 @@ parameters:
   value: latest
   displayName: git-partition-sync-consumer version
   description: git-partition-sync-consumer version which defaults to latest
-- name: INTERNAL_CERT_INIT_IMAGE
-  value: quay.io/app-sre/ubi8-ubi-minimal
-- name: INTERNAL_CERT_INIT_IMAGE_TAG
-  value: latest
-- name: INTERNAL_CERT_INIT_IMAGE_PULL_POLICY
-  value: Always
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: DRY_RUN
@@ -152,3 +137,6 @@ parameters:
   value: 150m
 - name: VAULT_SECRET_NAME
   value: git-partition-sync-consumer
+- name: INTERNAL_GIT_CA_PATH
+  description: 'path to certificate file to add in git config trust'
+  value: 'ca.crt'

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -9,15 +9,15 @@ import (
 
 // Push local repos to remotes
 func (d *Downloader) pushLatest(archives []*UntarInfo) error {
-	for _, archive := range archives {
+	// include command to trust internal git server certificate if set
+	caPath := os.Getenv("INTERNAL_GIT_CA_PATH")
 
+	for _, archive := range archives {
 		authURL, err := d.formatAuthURL(fmt.Sprintf("%s/%s", archive.RemoteGroup, archive.RemoteName))
 		if err != nil {
 			return err
 		}
 
-		// include command to trust internal git server certificate if path is set
-		caPath := os.Getenv("INTERNAL_GIT_CA_PATH")
 		var args []string
 		if len(caPath) > 0 {
 			args = []string{

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -25,7 +25,7 @@ func (d *Downloader) pushLatest(archives []*UntarInfo) error {
 				fmt.Sprintf("%s && %s && %s",
 					// this config must be set per repo (cannot be done once with --global flag)
 					// due to permission constraint when attempting to edit root gitconfig
-					fmt.Sprintf("git config http.sslCAInfo /etc/pki/ca-trust/source/anchors/ca.crt"),
+					fmt.Sprintf("git config http.sslCAInfo %s", caPath),
 					fmt.Sprintf("git remote add fedramp %s", authURL),
 					fmt.Sprintf("git push -u fedramp %s --force", archive.RemoteBranch),
 				),


### PR DESCRIPTION
Removes initContainer and mounts single ca file to import directly into main app container. 
App logic refactored to include git config command for importing the ca file per repo.