### PR TITLE
pivot to context with cancel

### DIFF
--- a/pkg/downloader.go
+++ b/pkg/downloader.go
@@ -66,7 +66,10 @@ func (d *Downloader) Run(ctx context.Context, dryRun bool) error {
 
 	d.initS3Client()
 
-	encryptedUpdates, err := d.getUpdatedObjects(ctx)
+	ctxCancel, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	encryptedUpdates, err := d.getUpdatedObjects(ctxCancel)
 	if err != nil {
 		return err
 	}

--- a/pkg/s3.go
+++ b/pkg/s3.go
@@ -91,11 +91,8 @@ func (d *Downloader) getUpdatedObjects(ctx context.Context) ([]EncryptedObject, 
 func (d *Downloader) getS3Object(ctx context.Context, key string, wg *sync.WaitGroup, ch chan<- S3object) {
 	defer wg.Done()
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
-
 	object := S3object{}
-	result, err := d.s3Client.GetObject(ctxTimeout, &s3.GetObjectInput{
+	result, err := d.s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &d.bucket,
 		Key:    &key,
 	})


### PR DESCRIPTION
Short-term fix for issue with timeout context utilized for s3 GetObject call canceling prematurely.