### PR TITLE
Checkout target branch locally

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -22,11 +22,12 @@ func (d *Downloader) pushLatest(archives []*UntarInfo) error {
 		if len(caPath) > 0 {
 			args = []string{
 				"-c",
-				fmt.Sprintf("%s && %s && %s",
+				fmt.Sprintf("%s && %s && %s && %s",
 					// this config must be set per repo (cannot be done once with --global flag)
 					// due to permission constraint when attempting to edit root gitconfig
 					fmt.Sprintf("git config http.sslCAInfo %s", caPath),
 					fmt.Sprintf("git remote add fedramp %s", authURL),
+					fmt.Sprintf("git checkout %s", archive.RemoteBranch),
 					fmt.Sprintf("git push -u fedramp %s --force", archive.RemoteBranch),
 				),
 			}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -34,8 +34,9 @@ func (d *Downloader) pushLatest(archives []*UntarInfo) error {
 		} else {
 			args = []string{
 				"-c",
-				fmt.Sprintf("%s && %s",
+				fmt.Sprintf("%s && %s && %s",
 					fmt.Sprintf("git remote add fedramp %s", authURL),
+					fmt.Sprintf("git checkout %s", archive.RemoteBranch),
 					fmt.Sprintf("git push -u fedramp %s --force", archive.RemoteBranch),
 				),
 			}


### PR DESCRIPTION
This is to ensure that the correct branch is pushed, even if default branch set on source repository differs.