### PR TITLE
Don't fatally error when reconciling

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,11 @@ func main() {
 		ctx := context.Background()
 		err = downloader.Run(ctx, dryRun, runOnce)
 		if err != nil {
-			log.Fatalln(err)
+			if runOnce {
+				log.Fatalln(err)
+			} else {
+				log.Println(err)
+			}
 		}
 
 		if runOnce {


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-8163

Very simple change to bring this integration more in line with other Qontract Integrations. If an error occurs during reconciliation, then log the error but don't exit the reconciliation cycle. This also means that the `qontract_reconcile_last_run_status` will correctly be exported to Prometheus since the app won't crash. Meaning we will get an alert of integration failure.