### PR TITLE
Use FIPS AWS Endpoints

### DIFF
--- a/openshift/consumer.yaml
+++ b/openshift/consumer.yaml
@@ -42,6 +42,8 @@ objects:
             value: ${VOLUME_PATH}/${WORKDIR}
           - name: INTERNAL_GIT_CA_PATH
             value: ${INTERNAL_GIT_CA_PATH}
+          - name: AWS_USE_FIPS_ENDPOINT
+            value: ${USE_FIPS}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
@@ -137,3 +139,6 @@ parameters:
 - name: INTERNAL_GIT_CA_PATH
   description: 'path to certificate file to add in git config trust'
   value: '/etc/pki/ca-trust/source/anchors/ca.crt'
+- name: USE_FIPS
+  description: whether to use FIPS endpoints when communicating with S3
+  value: "true"


### PR DESCRIPTION
[APPSRE-8491](https://issues.redhat.com/browse/APPSRE-8491)

Sets the OpenShift template to use FIPS endpoints when communicating to the S3 bucket stored in commercial.

Git Partition Sync Consumer uses the official AWS golang library which supports setting `AWS_USE_FIPS_ENDPOINT = "true"` which will enable FIPS connectivity. See https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html

Additionally, the S3 bucket where repos are downloaded from is in us-east-1 [which has a FIPS endpoint](https://aws.amazon.com/compliance/fips/)

![image](https://github.com/app-sre/git-partition-sync-consumer/assets/4098927/540494e0-3a6c-4e2d-8326-3b1ac7e108ef)
