### PR TITLE
Update builder, runtime base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM quay.io/app-sre/golang:1.18.5 AS builder
-WORKDIR /build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21.13-1.1727869850 as builder
+USER 0
+WORKDIR /workspace
 COPY . .
 RUN make test build
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4
-COPY --from=builder /build/git-partition-sync-consumer  /bin/git-partition-sync-consumer
+FROM registry.access.redhat.com/ubi9-minimal:9.4-1227.1726694542
+COPY --from=builder /workspace/git-partition-sync-consumer  /bin/git-partition-sync-consumer
 RUN microdnf update -y && microdnf install -y git
 
 ENTRYPOINT  [ "/bin/git-partition-sync-consumer" ]


### PR DESCRIPTION
This MR migrates builder to use use ubi/go-toolset and update runtime image to latest ubi-9 minimal image.